### PR TITLE
Compatibility with Matomo 4

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,9 +1,9 @@
 {
     "name": "LoginFailLog",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Logs failed login attempts together with user IP. Useful for protecting Piwik against brute force attacks via fail2ban or similar tools.",
     "require": {
-        "piwik": ">=3.0.0-b1,<4.0.0-b1"
+        "piwik": ">=3.0.0-b1,<5.0.0-b1"
     },
     "authors": [
         {


### PR DESCRIPTION
Hello!

The piwik version requirement in the `plugin.json` file leads to the following blocking message in the Matomo plugin management page:
```
LoginFailLog requires Piwik <4.0.0-b1
```
As mentionned in https://github.com/patrickbr/piwik-LoginFailLog/issues/6 , this adaptation leads to the expected generation of logs in case of invalid login attempt.